### PR TITLE
Updated Swift version in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.1
 ///
 /// Package.swift
 ///
@@ -25,6 +25,8 @@ let package = Package(
         products: [
             .library(name: "StickyEncoding", type: .dynamic, targets: ["StickyEncoding"])
         ],
+        dependencies: [
+        ],
         targets: [
             /// Module targets
             .target(name: "StickyEncoding", dependencies: [], path: "Sources/StickyEncoding"),
@@ -32,5 +34,5 @@ let package = Package(
             /// Tests
             .testTarget(name: "StickyEncodingTests", dependencies: ["StickyEncoding"], path: "Tests/StickyEncodingTests")
         ],
-        swiftLanguageVersions: [.v4_2]
+        swiftLanguageVersions: [.v5]
 )


### PR DESCRIPTION
## Description
Updated swift-tools-version and swiftLanguageVersions in Package.swift

## Motivation and Context
This is an attempt to fix an issue where projects using sticky-encoding as a dependency are not linking properly with the sticky-encoding library in Xcode 11.3.1, yielding binaries that do not run.

## How Has This Been Tested?
All unit tests were run in Xcode.

## Checklist:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced
     in the commit message?
- [X ] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [X ] Is your initial contribution a single, squashed commit?

### For code changes:
- [X ] Avoid other runtime dependencies
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] Have you ensured that the full suite of tests is executed via `make tests` in the cmake-build-debug` directory off the root of the project?
- [ ] If applicable, have you updated the documentation?
- [ ] If applicable, have you updated the [CHANGELOG.md](https://github.com/stickytools/sticky-encoding/blob/master/CHANGELOG.md) file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
